### PR TITLE
Use a stable (non-versioned) manifest URL so installs auto-update

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,13 +145,26 @@ async function run () {
     let versionNumber = fs.readFileSync('version.txt', 'utf-8')
     versionNumber = `v${versionNumber.trim()}`
 
-    // Set up Download URLs
+    // Set up Download / Manifest URLs.
+    //
+    // The `download` URL is per-version (Foundry fetches the exact release zip).
+    // The `manifest` URL is intentionally STABLE / non-versioned so that a copy
+    // installed from a manifest URL keeps detecting updates without the user
+    // re-pointing it every release (Foundry re-polls the installed manifest field).
+    //
+    //   - Free / public modules: the module repo's own `latest.json` on its default
+    //     branch (public, so the raw URL is reachable). `latest.json` is refreshed
+    //     each release by foundry-manifest-update-action.
+    //   - Protected modules: the non-versioned root manifest published to the public
+    //     content repo (publicRepositoryAndBranch), refreshed each release by
+    //     foundry-release-upload-action.
+    const defaultBranch = github.context.payload.repository.default_branch || 'main'
     let downloadURL = `https://github.com/${owner}/${repo}/releases/download/${versionNumber}/${repo}.zip`
-    let manifestURL = `https://github.com/${owner}/${repo}/releases/download/${versionNumber}/${manifestFileName}`
+    let manifestURL = `https://raw.githubusercontent.com/${owner}/${repo}/${defaultBranch}/latest.json`
     let manifestProtectedValue = 'false'
     if (manifestProtectedTrue === 'true') {
       downloadURL = ''
-      manifestURL = `https://raw.githubusercontent.com/${publicRepositoryAndBranch}/${repo}/${versionNumber}/${manifestFileName}`
+      manifestURL = `https://raw.githubusercontent.com/${publicRepositoryAndBranch}/${repo}/${manifestFileName}`
       manifestProtectedValue = 'true'
     }
 


### PR DESCRIPTION
## What
Point the package's `manifest` field at a **stable** URL instead of a versioned/frozen one:

- Free/public modules → the repo's own `latest.json` on its default branch
- Protected modules → the non-versioned root manifest in the public content repo

`download` stays per-version. The version-specific URL Foundry's Release API needs is produced by `foundry-package-release-action` (companion PR), not by this field.

## Why
Foundry re-fetches the installed package's `manifest` field to detect updates ([Package Management](https://foundryvtt.com/article/package-management/)). A versioned/frozen URL there means updates are never detected — the field should track "latest" ([Package Release API](https://foundryvtt.com/article/package-release-api/) note).

## ⚠️ Merge order
Merge **after** `foundry-package-release-action#versioned-release-api-manifest`. If this merges first, the Release API would receive the stable URL (wrong) until that PR lands.

## One-time transition
Existing installs that stored the old versioned URL keep polling it until their next reinstall/update; everything from the next release onward uses the stable URL. Listed packages also get Foundry's "adopt new manifest URL?" prompt.

## Verification
`node --check` + `standard` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)